### PR TITLE
Add Images to Content Section Hero

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -59,6 +59,7 @@ module.exports = {
     'gatsby-plugin-typescript',
     'gatsby-plugin-sharp',
     'gatsby-transformer-sharp',
-    'gatsby-plugin-react-helmet'
+    'gatsby-plugin-react-helmet',
+    'gatsby-remark-images'
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@emotion/styled": "^10.0.12",
     "@mdx-js/mdx": "^1.6.5",
     "@mdx-js/react": "^1.6.5",
+    "@types/mdx-js__react": "^1.5.2",
     "babel-plugin-styled-components": "^1.10.1",
     "classnames": "^2.2.6",
     "gatsby": "^2.10.0",

--- a/src/components/ContentSection.tsx
+++ b/src/components/ContentSection.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import styled from '@emotion/styled'
+import Content from './Content'
+import { HeroText, HeroImage } from './HeroBox'
 
 const StyledContentSection = styled.section`
   display: grid;
@@ -11,10 +13,24 @@ const StyledContentSection = styled.section`
 
 interface ContentSectionProps {
   className?: string
+  imgSrc?: string
+  imgAlt?: string
 }
 
-const ContentSection: React.FC<ContentSectionProps> = ({ children, className }) => (
-  <StyledContentSection className={className}>{children}</StyledContentSection>
-)
+const ContentSection: React.FC<ContentSectionProps> = ({ children, className, imgSrc, imgAlt }) => {
+  return (
+    <StyledContentSection className={className}>
+      <HeroText>A</HeroText>
+      <HeroImage>
+        <img src={imgSrc} alt={imgAlt} />
+      </HeroImage>
+
+      <Content>
+        <h2>Content Section</h2>
+        This is a content chunk
+      </Content>
+    </StyledContentSection>
+  )
+}
 
 export default ContentSection

--- a/src/components/HeroBox.tsx
+++ b/src/components/HeroBox.tsx
@@ -12,6 +12,7 @@ const StyledHeroImage = styled.div`
   justify-self: end;
   background: blue;
   width: 100%;
+  text-align: right;
 `
 interface HeroTextProps {
   className?: string

--- a/src/content/a-markdown-page.mdx
+++ b/src/content/a-markdown-page.mdx
@@ -3,23 +3,14 @@ layout: page
 title: 'Example Markdown page'
 ---
 
-import Content from '../components/Content'
-import { HeroText, HeroImage } from '../components/HeroBox'
-import ContentSection from '../components/ContentSection'
-
-<ContentSection>
-  <HeroText>A</HeroText>
-  <HeroImage>B</HeroImage>
-  <Content>
-    <h2>Content Section</h2>
-    This is a content chunk
-  </Content>
-</ContentSection>
+<ContentSection imgSrc="https://via.placeholder.com/350x350.png" imgAlt="Placeholder" />
 
 ## Example MDX Heading
 
 Now we're writing in Markdown! Pretty nice, huh?
 
 This starter has out-of-the-box support for basic Markdown rendering. The `content/` directory is where you put all of your Markdown content in. Gatsby will build your pages out of it. Gatsby will also follow the directory structure of your files too, so when you store a page at e.g. `content/projects/large-hadron-collider.md`, it will be built in `/projects/large-hadron-collider/`.
+
+![Example Image](https://via.placeholder.com/350x350.png)
 
 [That's cool! Okay, take me back home.](/)

--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -2,10 +2,15 @@ import * as React from 'react'
 import { graphql } from 'gatsby'
 
 import { MDXRenderer } from 'gatsby-plugin-mdx'
+import { MDXProvider } from '@mdx-js/react'
 import Page from '../components/Page'
 import Container from '../components/Container'
+import ContentSection from '../components/ContentSection'
 import IndexLayout from '../layouts'
 
+const shortcodes = {
+  ContentSection
+}
 interface PageTemplateProps {
   data: {
     site: {
@@ -32,7 +37,9 @@ const PageTemplate: React.FC<PageTemplateProps> = ({ data }) => {
       <Page>
         <Container>
           <h1>{post.frontmatter.title}</h1>
-          <MDXRenderer>{post.body}</MDXRenderer>
+          <MDXProvider components={shortcodes}>
+            <MDXRenderer>{post.body}</MDXRenderer>
+          </MDXProvider>
         </Container>
       </Page>
     </IndexLayout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,6 +2231,13 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/mdx-js__react@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@types/mdx-js__react/-/mdx-js__react-1.5.2.tgz#eb87df0ac135a685cc9bb01075a9036c7b395b0d"
+  integrity sha512-M/z869+SVti16ZGqMwg46XTNsBKj5/PNcId9NpjEUVPI2V8wzXpbkkhmhZy1n16nQvMAC6HJuh+Dogn8vPLV6w==
+  dependencies:
+    "@types/react" "*"
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
__Note: This needs merging _after_ https://github.com/guardian/guardian-engineering-site/pull/9__

## What does this change?
This makes the process of adding a content section more concise and allows an image URL to be passed to the component for rendering in the `HeroImage` child component.

This also adds the ability to add inline markdown of images to the ordinary `.mdx` files.

There's still work to do here around making the `ContentSection` more general - at the moment the text of the `Content` component is hardcoded in. This ideally needs to be made part of the mdx file in some way so that it can be queried by GraphQL and added in from there.

## Images
![image](https://user-images.githubusercontent.com/9122944/84288875-ae102280-ab39-11ea-84fd-7e04e2691330.png)
