### PR TITLE
Swap from master to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this change?
Uses `main` branch for deployment in `gh-actions`
