### PR TITLE
Mxdvl/blog feed images

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+tab_width = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/src/components/BlogFeed.astro
+++ b/src/components/BlogFeed.astro
@@ -1,0 +1,131 @@
+---
+import { timeAgo } from "@guardian/libs";
+
+type SeriesResult = {
+  id: string;
+  type: string;
+  sectionId: string;
+  sectionName: string;
+  webPublicationDate: string;
+  webTitle: string;
+  webUrl: string;
+  apiUrl: string;
+  isHosted: boolean;
+  pillarId: string;
+  pillarName: string;
+};
+
+const posts: SeriesResult[] = await fetch(
+  "https://content.guardianapis.com/search?tag=info%2Fseries%2Fengineering-blog&api-key=test"
+)
+  .then((r) => r.json())
+  .then((d) => d.response.results);
+
+/**
+ * It would be good to use https://raw.githubusercontent.com/guardian/dotcom-rendering/main/dotcom-rendering/src/model/json-schema.json
+ */
+type ArticleResult = {
+  mainMediaElements: Array<{
+    data: {
+      alt: string;
+      caption: string;
+      credit: string;
+    };
+    imageSources: Array<{
+      weighting: "inline" | "thumbnail" | "showcase" | "immersive";
+      srcSet: Array<{
+        src: `https://i.guim.co.uk/${string}`;
+        width: number;
+      }>;
+    }>;
+  }>;
+};
+---
+
+<h3>Latest Engineering blog posts</h3>
+<ul>
+  {posts.slice(0, 9).map(async (post) => {
+    const time = new Date(post.webPublicationDate).getTime();
+    const pubDate = timeAgo(time);
+
+    const article: ArticleResult = await fetch(post.webUrl + ".json?dcr").then(
+      (r) => r.json()
+    );
+
+    const media = article.mainMediaElements[0];
+
+    const image = media.imageSources
+      .find((source) => source.weighting === "inline")
+      .srcSet.slice()
+      .sort((a, b) => a.width - b.width)
+      .find((src) => src.width > 600);
+
+    return (
+      <li>
+        <a href={post.webUrl}>
+          <figure>
+            <img src={image.src} width={image.width} alt={media.data.alt} />
+          </figure>
+          <h4>{post.webTitle}</h4>
+          <h5>{pubDate}</h5>
+        </a>
+      </li>
+    );
+  })}
+</ul>
+
+<style lang="scss">
+  ul {
+    display: flex;
+    flex-wrap: wrap;
+    list-style-type: none;
+
+    li {
+      flex: 0 1 30%;
+      padding: 0.5rem;
+
+      a {
+        color: inherit;
+        text-decoration: none;
+        padding: 0.5rem;
+        display: block;
+        box-sizing: border-box;
+        height: 100%;
+        background-color: #333;
+      }
+
+      figure {
+        margin: 0;
+        padding-top: 75%;
+        width: 100%;
+        position: relative;
+        overflow: hidden;
+
+        img {
+          width: 100%;
+          height: 100%;
+          position: absolute;
+          top: 0;
+          left: 0;
+          object-fit: cover;
+        }
+      }
+
+      h4 {
+        padding-top: 0.5rem;
+      }
+
+      h4,
+      h5 {
+        margin: 0;
+      }
+
+      h5 {
+        padding-top: 0.5rem;
+        font-weight: normal;
+        text-decoration: none;
+        color: inherit;
+      }
+    }
+  }
+</style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -9,7 +9,8 @@ const branch = "mxdvl/astro"; // main
 <footer>
   <div>
     2021 — Made with ❤️ by <a href="https://twitter.com/gdndevelopers"
-      >Guardian developers</a>
+      >Guardian developers</a
+    >
   </div>
   {edit ? (
     <a

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,30 +1,10 @@
 ---
 import PageLayout from "../layouts/page.astro";
+import BlogFeed from "../components/BlogFeed.astro";
 import { Markdown } from "astro/components";
-import { timeAgo } from "@guardian/libs";
 
 import { border } from "../styles/shared.ts";
 import home from "/assets/home.jpg";
-
-type Result = {
-  id: string;
-  type: string;
-  sectionId: string;
-  sectionName: string;
-  webPublicationDate: string;
-  webTitle: string;
-  webUrl: string;
-  apiUrl: string;
-  isHosted: boolean;
-  pillarId: string;
-  pillarName: string;
-};
-
-const posts: Result[] = await fetch(
-  "https://content.guardianapis.com/search?tag=info%2Fseries%2Fengineering-blog&api-key=test"
-)
-  .then((r) => r.json())
-  .then((d) => d.response.results);
 ---
 
 <PageLayout edit="index.astro">
@@ -69,21 +49,7 @@ const posts: Result[] = await fetch(
     </ul>
   </section>
   <section id="engineering-blog-posts">
-    <h3>Latest Engineering blog posts</h3>
-    <ul>
-      {posts.slice(0, 9).map((post) => {
-        const time = new Date(post.webPublicationDate).getTime();
-        const pubDate = timeAgo(time);
-        return (
-          <li>
-            <a href={post.webUrl}>
-              <h4>{post.webTitle}</h4>
-              <h5>{pubDate}</h5>
-            </a>
-          </li>
-        );
-      })}
-    </ul>
+    <BlogFeed />
   </section>
 </PageLayout>
 
@@ -175,41 +141,6 @@ const posts: Result[] = await fetch(
         h4 {
           margin: 0;
           padding-bottom: 0.5em;
-        }
-      }
-    }
-  }
-
-  #engineering-blog-posts {
-    ul {
-      display: flex;
-      flex-wrap: wrap;
-      list-style-type: none;
-
-      li {
-        flex: 0 1 30%;
-        padding: 0.5rem;
-
-        a {
-          color: inherit;
-          text-decoration: none;
-          padding: 0.5rem;
-          display: block;
-          box-sizing: border-box;
-          height: 100%;
-          background-color: #333;
-        }
-
-        h4,
-        h5 {
-          margin: 0;
-        }
-
-        h5 {
-          padding-top: 0.5rem;
-          font-weight: normal;
-          text-decoration: none;
-          color: inherit;
         }
       }
     }

--- a/src/pages/open.astro
+++ b/src/pages/open.astro
@@ -108,7 +108,10 @@ const repos = reposRaw
               <h4>{repo.name}</h4>
               <h5>
                 ({repo.stargazers_count} stars - updated{" "}
-                {timeAgo(repo.updated_at, { daysUntilAbsolute: 1 })})
+                {timeAgo(repo.updated_at, {
+                  daysUntilAbsolute: 1,
+                })}
+                )
               </h5>
               <p>{repo.description}</p>
             </a>


### PR DESCRIPTION
## What does this change?

Adds images to the latest blog posts.

## How to test

See the deployment.

## How can we measure success?

More attractive blog posts!

## Images

![blog feed with pictures](https://user-images.githubusercontent.com/76776/145571665-4b9a2cab-cc93-4fcd-9417-0971703b3422.png)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [X] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [X] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [X] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
