### PR TITLE
Split "open" pages

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -7,11 +7,11 @@ const { path } = Astro.props;
 <nav>
   <a class={path === "/" ? "active" : ""} href="/"> Home </a>
 
-  <a class={path === "/open" ? "active" : ""} href="/open#people">
+  <a class={path === "/open-people" ? "active" : ""} href="/open-people">
     Open People
   </a>
 
-  <a class={path === "/open" ? "active" : ""} href="/open#source">
+  <a class={path === "/open-source" ? "active" : ""} href="/open-source">
     Open Source
   </a>
 

--- a/src/pages/open-people.astro
+++ b/src/pages/open-people.astro
@@ -1,0 +1,68 @@
+---
+import PageLayout from "../layouts/page.astro";
+import { Markdown } from "astro/components";
+
+import { border } from "../styles/shared.ts";
+
+const url =
+  "https://raw.githubusercontent.com/guardian/our-engineering-culture/master/README.md";
+const content = await fetch(url).then((r) => r.text());
+---
+
+<PageLayout title="Open People" edit="open-people.astro">
+  <section id="people">
+    <Markdown>
+      # Open People
+
+      As defined in our [engineering culture][], the key pillars are:
+
+      [engineering culture]: https://github.com/guardian/our-engineering-culture
+    </Markdown>
+    <ul>
+      <!-- Extract titles from markdown for linking to sections directly -->
+      {content
+        .split("\n")
+        .filter((line) => line.startsWith("#### "))
+        .map((pillar) => {
+          const name = pillar.slice(5);
+          const link = name
+            .trim()
+            .replaceAll("&", "")
+            .replaceAll(" ", "-")
+            .toLowerCase();
+          return (
+            <li>
+              <a href={`#${link}`}>{name}</a>
+            </li>
+          );
+        })}
+    </ul>
+
+    <hr />
+
+    <Markdown {content}>
+
+    </Markdown>
+  </section>
+</PageLayout>
+
+<style lang="scss" define:vars={{ border }}>
+  section {
+    padding: 0 1rem;
+
+    // All but the first section
+    &:nth-of-type(n + 2) {
+      border-top: var(--border);
+    }
+
+    p,
+    ul {
+      max-width: 36rem;
+    }
+  }
+
+  hr {
+    border: none;
+    border-top: var(--border);
+  }
+</style>

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -34,7 +34,7 @@ const repos = reposRaw
     <Markdown>
       # Open Source
 
-      The source code is at [github.com/guardian](https://github.com/guardian)
+      Our source code is available at [github.com/guardian](https://github.com/guardian)
 
       ## What we work with
 

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -5,10 +5,6 @@ import { Markdown } from "astro/components";
 
 import { border } from "../styles/shared.ts";
 
-const url =
-  "https://raw.githubusercontent.com/guardian/our-engineering-culture/master/README.md";
-const content = await fetch(url).then((r) => r.text());
-
 const reposUrl = `https://api.github.com/orgs/guardian/repos?per_page=100&sort=updated&direction=desc`;
 const reposRaw: Array<{
   name: string;
@@ -33,42 +29,7 @@ const repos = reposRaw
   .slice(0, 10);
 ---
 
-<PageLayout title="Open People &amp; Source" edit="open.astro">
-  <section id="people">
-    <Markdown>
-      # Open People
-
-      As defined in our [engineering culture][], the key pillars are:
-
-      [engineering culture]: https://github.com/guardian/our-engineering-culture
-    </Markdown>
-    <ul>
-      <!-- Extract titles from markdown for linking to sections directly -->
-      {content
-        .split("\n")
-        .filter((line) => line.startsWith("#### "))
-        .map((pillar) => {
-          const name = pillar.slice(5);
-          const link = name
-            .trim()
-            .replaceAll("&", "")
-            .replaceAll(" ", "-")
-            .toLowerCase();
-          return (
-            <li>
-              <a href={`#${link}`}>{name}</a>
-            </li>
-          );
-        })}
-    </ul>
-
-    <hr />
-
-    <Markdown {content}>
-
-    </Markdown>
-  </section>
-
+<PageLayout title="Open Source" edit="open-source.astro">
   <section id="source">
     <Markdown>
       # Open Source
@@ -140,9 +101,6 @@ const repos = reposRaw
   hr {
     border: none;
     border-top: var(--border);
-  }
-
-  #people {
   }
 
   #source {


### PR DESCRIPTION
## What does this change?

I found the navigation for "open people" and "open source" confusing as it would jump to sections within the same page and lose the navigation, whereas the other nav items link to separate pages.

This PR (assuming its okay to change the structure) splits the sections into separate pages.

## Images

Before:

<img width="481" alt="Screenshot 2022-01-07 at 13 48 51" src="https://user-images.githubusercontent.com/7014230/148563180-521899cd-d795-4c7b-b882-0811495af3bd.png">

<img width="730" alt="Screenshot 2022-01-07 at 15 06 00" src="https://user-images.githubusercontent.com/7014230/148563467-0b49574d-6567-46f7-b50d-345940a9d3e0.png">

After:

<img width="716" alt="Screenshot 2022-01-07 at 15 04 57" src="https://user-images.githubusercontent.com/7014230/148563235-577a6e6a-2a38-4ef6-af5f-eac0810ad382.png">

<img width="724" alt="Screenshot 2022-01-07 at 15 05 09" src="https://user-images.githubusercontent.com/7014230/148563254-2f280c35-10b0-448e-ad9d-0852adea0bb0.png">

