### PR TITLE
Bump dependencies (2021-01-07)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "validate": "prettier src --plugin=prettier-plugin-astro --check"
   },
   "devDependencies": {
-    "@astrojs/renderer-preact": "^0.3.0",
     "@astrojs/renderer-react": "^0.3.0",
     "@babel/core": "^7.16.0",
     "@emotion/react": "^11.7.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "npm-check-updates": "^12",
     "prettier-plugin-astro": "^0.0.11",
     "react": "^17.0.2",
-    "vite": "^2.6.14",
+    "vite": "^2.7.10",
     "web-vitals": "^2.1.2"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,6 @@
 lockfileVersion: 5.3
 
 specifiers:
-  '@astrojs/renderer-preact': ^0.3.0
   '@astrojs/renderer-react': ^0.3.0
   '@babel/core': ^7.16.0
   '@emotion/core': ^11.0.0
@@ -22,7 +21,6 @@ dependencies:
   '@guardian/source-react-components': 4.0.0-rc.2_1d19db2fde19f6cae2945a49706e29c2
 
 devDependencies:
-  '@astrojs/renderer-preact': 0.3.0_@babel+core@7.16.0
   '@astrojs/renderer-react': 0.3.0_@babel+core@7.16.0
   '@babel/core': 7.16.0
   '@emotion/react': 11.7.0_@babel+core@7.16.0+react@17.0.2
@@ -98,17 +96,6 @@ packages:
   /@astrojs/prism/0.3.0:
     resolution: {integrity: sha512-5U+jcgfibLKW8PwnHQEdmgb+uZVeMVLz+paEr3vxKgikYfjXDjQu6qEDLOW3WTc/cIWrOF9rAtTKy8R/ArPscw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
-
-  /@astrojs/renderer-preact/0.3.0_@babel+core@7.16.0:
-    resolution: {integrity: sha512-gw+LpSdJXeSXdMTc9aIvVHiOyBs9w37D1yGogE/cleStIN9nTM6TVeU06gtZkIHOViOGAsMXTCrM7enr6VBMKQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      '@babel/plugin-transform-react-jsx': 7.16.0_@babel+core@7.16.0
-      preact: 10.6.1
-      preact-render-to-string: 5.1.19_preact@10.6.1
-    transitivePeerDependencies:
-      - '@babel/core'
     dev: true
 
   /@astrojs/renderer-preact/0.3.2_@babel+core@7.16.0:
@@ -4240,21 +4227,8 @@ packages:
       pretty-format: 3.8.0
     dev: true
 
-  /preact-render-to-string/5.1.19_preact@10.6.1:
-    resolution: {integrity: sha512-bj8sn/oytIKO6RtOGSS/1+5CrQyRSC99eLUnEVbqUa6MzJX5dYh7wu9bmT0d6lm/Vea21k9KhCQwvr2sYN3rrQ==}
-    peerDependencies:
-      preact: '>=10'
-    dependencies:
-      preact: 10.6.1
-      pretty-format: 3.8.0
-    dev: true
-
   /preact/10.5.15:
     resolution: {integrity: sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==}
-    dev: true
-
-  /preact/10.6.1:
-    resolution: {integrity: sha512-ydCg+ISIq70vqiThvNWStZWLRjR9U2awP/JAmGdWUKm9+Tyuy+MqVdAIyEByeIspAVtD4GWC/SJtxO8XD4knVA==}
     dev: true
 
   /prepend-http/2.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   npm-check-updates: ^12
   prettier-plugin-astro: ^0.0.11
   react: ^17.0.2
-  vite: ^2.6.14
+  vite: ^2.7.10
   web-vitals: ^2.1.2
 
 dependencies:
@@ -31,7 +31,7 @@ devDependencies:
   npm-check-updates: 12.0.2
   prettier-plugin-astro: 0.0.11
   react: 17.0.2
-  vite: 2.6.14
+  vite: 2.7.10
   web-vitals: 2.1.2
 
 packages:
@@ -144,11 +144,11 @@ packages:
       - '@babel/core'
     dev: true
 
-  /@astrojs/renderer-svelte/0.2.2_a945ca5b6c257932c1c7ea9fa4388175:
+  /@astrojs/renderer-svelte/0.2.2_f5af23e5d2bc9fb8f00acfdebc08ae0e:
     resolution: {integrity: sha512-6fs/skQURDvn2K/TVAgOmqcMUaGuocV7EwAzthHTJzlfRQUbNEWmyLtuvjcSCZnY+28vupKjEarWl3IsyqJh6Q==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.30_svelte@3.44.2+vite@2.6.14
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.30_svelte@3.44.2+vite@2.7.10
       svelte: 3.44.2
       svelte-preprocess: 4.9.8_9675c6fff70bd4de7ee4e280e30902e9
     transitivePeerDependencies:
@@ -168,11 +168,11 @@ packages:
       - vite
     dev: true
 
-  /@astrojs/renderer-vue/0.2.1_vite@2.6.14:
+  /@astrojs/renderer-vue/0.2.1_vite@2.7.10:
     resolution: {integrity: sha512-nawWIzwL40M8ran4zQaYckAdHwn1HeD6zTRH3LKCENeAjn3bJ4wxJ2KD9dZw4twACP+yBZm3y2N7iX+6CyueIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
-      '@vitejs/plugin-vue': 1.10.1_vite@2.6.14
+      '@vitejs/plugin-vue': 1.10.1_vite@2.7.10
       vue: 3.2.23
     transitivePeerDependencies:
       - vite
@@ -663,7 +663,7 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.30_svelte@3.44.2+vite@2.6.14:
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.30_svelte@3.44.2+vite@2.7.10:
     resolution: {integrity: sha512-YQqdMxjL1VgSFk4/+IY3yLwuRRapPafPiZTiaGEq1psbJYSNYUWx9F1zMm32GMsnogg3zn99mGJOqe3ld3HZSg==}
     engines: {node: ^14.13.1 || >= 16}
     peerDependencies:
@@ -681,7 +681,7 @@ packages:
       require-relative: 0.8.7
       svelte: 3.44.2
       svelte-hmr: 0.14.7_svelte@3.44.2
-      vite: 2.6.14_sass@1.43.5
+      vite: 2.7.10_sass@1.43.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -833,13 +833,13 @@ packages:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: true
 
-  /@vitejs/plugin-vue/1.10.1_vite@2.6.14:
+  /@vitejs/plugin-vue/1.10.1_vite@2.7.10:
     resolution: {integrity: sha512-oL76QETMSpVE9jIScirGB2bYJEVU/+r+g+K7oG+sXPs9TZljqveoVRsmLyXlMZTjpQkLL8gz527cW80NMGVKJg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       vite: ^2.5.10
     dependencies:
-      vite: 2.6.14_sass@1.43.5
+      vite: 2.7.10_sass@1.43.5
     dev: true
 
   /@vue/compiler-core/3.2.23:
@@ -1070,8 +1070,8 @@ packages:
       '@astrojs/prism': 0.3.0
       '@astrojs/renderer-preact': 0.3.2_@babel+core@7.16.0
       '@astrojs/renderer-react': 0.3.1_@babel+core@7.16.0
-      '@astrojs/renderer-svelte': 0.2.2_a945ca5b6c257932c1c7ea9fa4388175
-      '@astrojs/renderer-vue': 0.2.1_vite@2.6.14
+      '@astrojs/renderer-svelte': 0.2.2_f5af23e5d2bc9fb8f00acfdebc08ae0e
+      '@astrojs/renderer-vue': 0.2.1_vite@2.7.10
       '@babel/core': 7.16.0
       '@babel/traverse': 7.16.3
       '@proload/core': 0.2.2
@@ -1114,7 +1114,7 @@ packages:
       strip-ansi: 7.0.1
       supports-esm: 1.0.0
       tsconfig-resolver: 3.0.1
-      vite: 2.6.14_sass@1.43.5
+      vite: 2.7.10_sass@1.43.5
       yargs-parser: 20.2.9
       zod: 3.11.6
     transitivePeerDependencies:
@@ -4222,6 +4222,15 @@ packages:
       source-map-js: 1.0.1
     dev: true
 
+  /postcss/8.4.5:
+    resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.1.30
+      picocolors: 1.0.0
+      source-map-js: 1.0.1
+    dev: true
+
   /preact-render-to-string/5.1.19_preact@10.5.15:
     resolution: {integrity: sha512-bj8sn/oytIKO6RtOGSS/1+5CrQyRSC99eLUnEVbqUa6MzJX5dYh7wu9bmT0d6lm/Vea21k9KhCQwvr2sYN3rrQ==}
     peerDependencies:
@@ -5410,8 +5419,8 @@ packages:
       vfile-message: 3.0.2
     dev: true
 
-  /vite/2.6.14:
-    resolution: {integrity: sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==}
+  /vite/2.7.10:
+    resolution: {integrity: sha512-KEY96ntXUid1/xJihJbgmLZx7QSC2D4Tui0FdS0Old5OokYzFclcofhtxtjDdGOk/fFpPbHv9yw88+rB93Tb8w==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -5427,15 +5436,15 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.13.15
-      postcss: 8.4.1
+      postcss: 8.4.5
       resolve: 1.20.0
       rollup: 2.60.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vite/2.6.14_sass@1.43.5:
-    resolution: {integrity: sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==}
+  /vite/2.7.10_sass@1.43.5:
+    resolution: {integrity: sha512-KEY96ntXUid1/xJihJbgmLZx7QSC2D4Tui0FdS0Old5OokYzFclcofhtxtjDdGOk/fFpPbHv9yw88+rB93Tb8w==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -5451,7 +5460,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.13.15
-      postcss: 8.4.1
+      postcss: 8.4.5
       resolve: 1.20.0
       rollup: 2.60.1
       sass: 1.43.5

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+theguardian.engineering 


### PR DESCRIPTION
- Bump @astrojs/renderer-react from 0.3.1 to 0.4.0
- bump vite
- remove preact renderer
