### PR TITLE
Remove @astrojs/renderer-preact from config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,8 +8,7 @@
 
 // @ts-check
 export default /** @type {import('astro').AstroUserConfig} */ ({
-  // Enable the Preact renderer to support Preact JSX components.
-  renderers: ["@astrojs/renderer-preact", "@astrojs/renderer-react"],
+  renderers: ["@astrojs/renderer-react"],
   buildOptions: {
     site: "https://theguardian.engineering/",
   },


### PR DESCRIPTION
## What does this change?

#149 removed `@astrojs/renderer-preact` as a dependency, and so it needs to be removed from the Astro configuration too. `@astrojs/renderer-preact` is a dependency of `astro`, which is why the build was still working.