### PR TITLE
Downgrade Astro to fix emotion rendering bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/core": "7.16.7",
     "@emotion/react": "11.7.1",
     "@guardian/libs": "3.6.0",
-    "astro": "0.21.13",
+    "astro": "0.21.12",
     "npm-check-updates": "12.1.0",
     "prettier-plugin-astro": "0.0.11",
     "react": "17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@guardian/libs': 3.6.0
   '@guardian/source-foundations': 4.0.0-rc.5
   '@guardian/source-react-components': 4.0.0-rc.3
-  astro: 0.21.13
+  astro: 0.21.12
   npm-check-updates: 12.1.0
   prettier-plugin-astro: 0.0.11
   react: 17.0.2
@@ -25,7 +25,7 @@ devDependencies:
   '@babel/core': 7.16.7
   '@emotion/react': 11.7.1_@babel+core@7.16.7+react@17.0.2
   '@guardian/libs': 3.6.0_web-vitals@2.1.3
-  astro: 0.21.13
+  astro: 0.21.12
   npm-check-updates: 12.1.0
   prettier-plugin-astro: 0.0.11
   react: 17.0.2
@@ -131,8 +131,8 @@ packages:
       - '@babel/core'
     dev: true
 
-  /@astrojs/renderer-svelte/0.2.3_a8595b12897673c443cd296717300447:
-    resolution: {integrity: sha512-E/QbgqdnafPnTzRsfKR/IF8oDuqM65/yAdeZxAWwU0rvacRS2vjCwfQI38lPEAGdGt/NNQ29YJXoh6hWpjAEoA==}
+  /@astrojs/renderer-svelte/0.2.2_a8595b12897673c443cd296717300447:
+    resolution: {integrity: sha512-6fs/skQURDvn2K/TVAgOmqcMUaGuocV7EwAzthHTJzlfRQUbNEWmyLtuvjcSCZnY+28vupKjEarWl3IsyqJh6Q==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       '@sveltejs/vite-plugin-svelte': 1.0.0-next.30_svelte@3.44.2+vite@2.7.10
@@ -163,10 +163,6 @@ packages:
       vue: 3.2.23
     transitivePeerDependencies:
       - vite
-    dev: true
-
-  /@astropub/webapi/0.4.0:
-    resolution: {integrity: sha512-KpHOH9WsIJk2E3Z/suAZri3a6I9GrkZnmm+BHAZp4OBAXUUyNTIid9mIC8tiiHNbY2A6OLbBvfteuD+BYQfcrw==}
     dev: true
 
   /@babel/code-frame/7.16.7:
@@ -1032,8 +1028,8 @@ packages:
     hasBin: true
     dev: true
 
-  /astro/0.21.13:
-    resolution: {integrity: sha512-Wm72q/9KXo0DiAHlQttNSk7cBy7RtqXRj1BL2zjh2zRg6583v30yzSZl4YiJD2PA+TXBc+p4FNyq3med1YEyCw==}
+  /astro/0.21.12:
+    resolution: {integrity: sha512-58vEFjNE97rw84G2s8C8+FbBwPyurIFghaqK5rKouGgJ9aRcXMshsM81mdensz03yO3Y6VdRhyDexiz7eFiUWw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0, npm: '>=6.14.0'}
     hasBin: true
     dependencies:
@@ -1043,9 +1039,8 @@ packages:
       '@astrojs/prism': 0.3.0
       '@astrojs/renderer-preact': 0.3.2_@babel+core@7.16.7
       '@astrojs/renderer-react': 0.3.1_@babel+core@7.16.7
-      '@astrojs/renderer-svelte': 0.2.3_a8595b12897673c443cd296717300447
+      '@astrojs/renderer-svelte': 0.2.2_a8595b12897673c443cd296717300447
       '@astrojs/renderer-vue': 0.2.1_vite@2.7.10
-      '@astropub/webapi': 0.4.0
       '@babel/core': 7.16.7
       '@babel/traverse': 7.16.7
       '@proload/core': 0.2.2
@@ -1056,17 +1051,17 @@ packages:
       ci-info: 3.3.0
       connect: 3.7.0
       eol: 0.9.1
-      es-module-lexer: 0.9.3
+      es-module-lexer: 0.7.1
       esbuild: 0.13.7
       estree-util-value-to-estree: 1.3.0
       estree-walker: 3.0.0
       fast-glob: 3.2.7
-      fast-xml-parser: 4.0.1
+      fast-xml-parser: 3.21.1
       html-entities: 2.3.2
       htmlparser2: 7.2.0
       kleur: 4.1.4
       magic-string: 0.25.7
-      mime: 3.0.0
+      mime: 2.6.0
       morphdom: 2.6.1
       node-fetch: 3.1.0
       parse5: 6.0.1
@@ -1089,7 +1084,7 @@ packages:
       supports-esm: 1.0.0
       tsconfig-resolver: 3.0.1
       vite: 2.7.10_sass@1.43.5
-      yargs-parser: 21.0.0
+      yargs-parser: 20.2.9
       zod: 3.11.6
     transitivePeerDependencies:
       - coffeescript
@@ -1688,8 +1683,8 @@ packages:
       unbox-primitive: 1.0.1
     dev: true
 
-  /es-module-lexer/0.9.3:
-    resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
+  /es-module-lexer/0.7.1:
+    resolution: {integrity: sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==}
     dev: true
 
   /es-to-primitive/1.2.1:
@@ -2116,8 +2111,8 @@ packages:
     resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
     dev: true
 
-  /fast-xml-parser/4.0.1:
-    resolution: {integrity: sha512-EN1yOXDmMqpHrqkwTlCJDvFjepJBoBxjLRDtDxFmqrBILGV3NyFWpmcsofSKCCzc+YxhvNreB5rcKzG+TlyWpg==}
+  /fast-xml-parser/3.21.1:
+    resolution: {integrity: sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==}
     hasBin: true
     dependencies:
       strnum: 1.0.5
@@ -3626,9 +3621,9 @@ packages:
     hasBin: true
     dev: true
 
-  /mime/3.0.0:
-    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
-    engines: {node: '>=10.0.0'}
+  /mime/2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
     hasBin: true
     dev: true
 
@@ -5606,9 +5601,9 @@ packages:
       decamelize: 1.2.0
     dev: true
 
-  /yargs-parser/21.0.0:
-    resolution: {integrity: sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==}
-    engines: {node: '>=12'}
+  /yargs-parser/20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
     dev: true
 
   /yocto-queue/0.1.0:


### PR DESCRIPTION
## What does this change?

Downgrade Astro back to `0.21.12`, to fix an emotion bug.

## How to test

Visit the live website: [theguardian.engineering](https://theguardian.engineering/)

## How can we measure success?

Beautiful icons.

## Images

![image](https://user-images.githubusercontent.com/76776/148815280-18c746a8-6337-4f06-b2d0-b237e4601736.png)
