### PR TITLE
Stop bumping dependencies for Gatsby

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,5 +11,8 @@
       "automerge": true,
       "automergeType": "squash"
     }
-  ]
+  ],
+  "ignorePaths": [
+      "gatsby/*"
+  ],
 }


### PR DESCRIPTION
## What does this change?

Don’t bump dependencies in Gatsby: it’s a legacy project.

## How to test

Look at the Renovate updates.

## How can we measure success?

No more PRs like #158, which bump deps in the `gatsby` folder

## Have we considered potential risks?

The Gatsby project is there as an archive, it’s not meant to be run.