### PR TITLE
Fill out Open Source page

### DIFF
--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -34,7 +34,7 @@ const repos = reposRaw
     <Markdown>
       # Open Source
 
-      We at the Guardian try to be [as open and transparent as possible](https://www.theguardian.com/info/developer-blog/2014/nov/28/developing-in-the-open). 
+      We at the Guardian try to be [as open and transparent as possible](https://www.theguardian.com/info/developer-blog/2014/nov/28/developing-in-the-open).
       That means developing in public repositories where anyone can see our work. You can explore our
       source code on [GitHub](https://github.com/guardian).
 
@@ -53,7 +53,7 @@ const repos = reposRaw
       - [React](https://reactjs.org/)
       - [Preact](https://preactjs.com/)
       - [Play](https://www.playframework.com/)
-      - [Astro](https://astro.build/)
+      - [Astro](https://astro.build/) (which we use for this very site!)
 
       ### Tools
 

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -34,28 +34,33 @@ const repos = reposRaw
     <Markdown>
       # Open Source
 
-      Our source code is available at [github.com/guardian](https://github.com/guardian)
+      We at the Guardian try to be [as open and transparent as possible](https://www.theguardian.com/info/developer-blog/2014/nov/28/developing-in-the-open). 
+      That means developing in public repositories where anyone can see our work. You can explore our
+      source code on [GitHub](https://github.com/guardian).
 
       ## What we work with
 
       ### Languages
 
       - [Scala](https://www.scala-lang.org/)
+      - [Kotlin](https://kotlinlang.org/)
       - [JavaScript](https://www.javascript.com/)
       - [TypeScript](https://www.typescriptlang.org/)
+      - [Python](https://www.python.org/)
 
       ### Frameworks
 
       - [React](https://reactjs.org/)
       - [Preact](https://preactjs.com/)
       - [Play](https://www.playframework.com/)
+      - [Astro](https://astro.build/)
 
       ### Tools
 
       - [Storybook](https://storybook.js.org/)
       - [Elasticsearch](https://www.elastic.co/)
 
-      There are plenty more where these came from, but they are good starting points. If you want to
+      There are plenty more where these came from, but they are good starting points. And if you want to
       see our code in action...
 
       ## Here’s 10 recently updated repositories:


### PR DESCRIPTION
This PR adds more information about the department's ethos of developing in the open (linking to [Robert Rees' engineering blog post on the subject](https://www.theguardian.com/info/developer-blog/2014/nov/28/developing-in-the-open)), as well filling out the lists of languages, frameworks, and tools we use.

![image](https://user-images.githubusercontent.com/11380557/149504088-52682adc-9bc4-4f66-b7fb-316af3056041.png)

Any suggestions on other good languages/frameworks/tools to include are very welcome.