### PR TITLE
Remove events from nav bar, add recent events

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -22,10 +22,6 @@ const { path } = Astro.props;
   <a class={path === "/progression" ? "active" : ""} href="/progression">
     Progression
   </a>
-
-  <a class={path === "/events" ? "active" : ""} href="/events">
-    Events &amp; Talks
-  </a>
 </nav>
 
 <style lang="scss" define:vars={{ border }}>

--- a/src/pages/events.md
+++ b/src/pages/events.md
@@ -6,6 +6,8 @@ edit: "events.md"
 
 Here's a list of events and talks:
 
-- June 2020
-- July 2020
-- August 2020
+- Hack day with Fastly - 26 Jan 2022
+- Cop26 Hack day - 17 Sep 2021
+- [Scalabase Conference - 24 May 2021](https://www.47deg.com/blog/scalabase-video/)
+- Accessibility Hack Day - 22 Apr 2021
+- Diversity Hack Day - 26 Nov 2020


### PR DESCRIPTION
## What does this change?

* Remove events tab from the main nav due to insufficient content
* Adds some recent events to the events source file

<img width="727" alt="Screenshot 2022-01-14 at 10 21 54" src="https://user-images.githubusercontent.com/705427/149499912-591ebe4e-ca80-485d-a930-7b76cc0eb7a8.png">

