### PR TITLE
Remove number badges from 'cause' cards

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -137,21 +137,6 @@ import home from "/assets/home-digital-development.jpg";
         background-color: #333;
         position: relative;
 
-        &::after {
-          position: absolute;
-          top: -0.75em;
-          right: -0.75em;
-          counter-increment: card;
-          content: counter(card);
-          background-color: #ccc;
-          color: #111;
-          width: 1.5em;
-          height: 1.5em;
-          line-height: 1.4em;
-          border-radius: 1em;
-          text-align: center;
-        }
-
         h4 {
           margin: 0;
           padding-bottom: 0.5em;


### PR DESCRIPTION
## What does this change?

This is subjective so completely for your consideration.

I felt that the number badges are not adding much to the UX so this PR removes them.

## Images

Before:

<img width="1267" alt="Screenshot 2022-01-18 at 01 10 17" src="https://user-images.githubusercontent.com/7014230/149954295-7c7a0c29-59eb-4997-a226-415f7ef4ba77.png">

<img width="505" alt="Screenshot 2022-01-18 at 01 10 46" src="https://user-images.githubusercontent.com/7014230/149954376-125d3945-c4a9-4c51-a86d-2ef37c5463e1.png">

After:

<img width="1264" alt="Screenshot 2022-01-18 at 01 10 07" src="https://user-images.githubusercontent.com/7014230/149954356-b2e59b12-1014-407f-9cac-88b79d585875.png">

<img width="503" alt="Screenshot 2022-01-18 at 01 11 03" src="https://user-images.githubusercontent.com/7014230/149954407-f934cefc-6b31-4a93-a6bb-26f47e6e5811.png">

