### PR TITLE
Fix homepage card spacing issue

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,14 +29,10 @@ import home from "/assets/home-digital-development.jpg";
         and delightful stories.
       </li>
       <li>
-        <Markdown>
-          #### Coding in the open
-
-          We do much of our coding in public. Check out [our GitHub profile][] to see what
-          we’ve been working on.
-
-          [our github profile]: https://github.com/guardian
-        </Markdown>
+        <h4>Coding in the open</h4>
+        We do much of our coding in public. Check out <a
+          href="https://github.com/guardian">our GitHub profile</a
+        > to see what we’ve been working on.
       </li>
       <li>
         <h4>Moving fast</h4>


### PR DESCRIPTION
I noticed that the space between headers and text on homepage cards in `index.astro` wasn't consistent (see the 'Coding in the open' one below). It looks like having one of the cards in Markdown and the others in HTML was causing a discrepancy in spacing. This PR makes the four of them consistent by making them all HTML. I know Markdown is a bit cleaner but an `<a>` element seems harmless enough here.

Before

![image](https://user-images.githubusercontent.com/11380557/149964994-7d2deb66-f35b-4d93-97b4-7a9c4372364c.png)

After

![image](https://user-images.githubusercontent.com/11380557/149973345-9f095c27-7766-4fa8-a095-8199380cbad9.png)

