### PR TITLE
Add alt text to homepage image

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,11 @@ import home from "/assets/home-digital-development.jpg";
     </div>
 
     <div class="flexedImage">
-      <img id="home" src={home} />
+      <img
+        id="home"
+        src={home}
+        alt="Five people gathered around a table, with a man in the centre wearing an 'I heart the Guardian' tshirt"
+      />
     </div>
   </section>
 


### PR DESCRIPTION
Small PR to add riveting alt text to the new homepage image. This Improves accessibility, bumps up the Lighthouse rating from 82 to 100, and gives SEO a little boost too. A meta description is needed for a perfect SEO score but I figured that's something for another PR. 

Before 

![image](https://user-images.githubusercontent.com/11380557/149980167-27904c02-cf9f-41b0-a0f3-84c883ef580d.png)

After

![image](https://user-images.githubusercontent.com/11380557/149979983-ae299da2-2f09-4507-8ed8-2beed2064dff.png)
