### PR TITLE
refactor: Load CAPI API key from environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+CAPI_KEY=test

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,8 @@ jobs:
         run: |
           pnpm run build -- --verbose
           touch ./dist/.nojekyll
+        env:
+          CAPI_KEY: ${{ secrets.CAPI_KEY }}
 
       - name: Deploy if `main`
         uses: peaceiris/actions-gh-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # environment variables
-.env
 .env.production
 
 # macOS-specific files

--- a/src/components/BlogFeed.astro
+++ b/src/components/BlogFeed.astro
@@ -1,5 +1,6 @@
 ---
 import { timeAgo } from "@guardian/libs";
+const { CAPI_KEY } = import.meta.env;
 
 type SeriesResult = {
   id: string;
@@ -18,8 +19,13 @@ type SeriesResult = {
   };
 };
 
+const queryParams = new URLSearchParams();
+queryParams.append("tag", "info/series/engineering-blog");
+queryParams.append("show-fields", "byline");
+queryParams.append("api-key", CAPI_KEY);
+
 const posts: SeriesResult[] = await fetch(
-  "https://content.guardianapis.com/search?tag=info%2Fseries%2Fengineering-blog&show-fields=byline&api-key=test"
+  `https://content.guardianapis.com/search?${queryParams.toString()}`
 )
   .then((r) => r.json())
   .then((d) => d.response.results);

--- a/src/components/BlogFeed.astro
+++ b/src/components/BlogFeed.astro
@@ -22,7 +22,7 @@ type SeriesResult = {
 const queryParams = new URLSearchParams();
 queryParams.append("tag", "info/series/engineering-blog");
 queryParams.append("show-fields", "byline");
-queryParams.append("api-key", CAPI_KEY);
+queryParams.append("api-key", CAPI_KEY ?? "test");
 
 const posts: SeriesResult[] = await fetch(
   `https://content.guardianapis.com/search?${queryParams.toString()}`

--- a/src/components/BlogFeed.astro
+++ b/src/components/BlogFeed.astro
@@ -19,10 +19,11 @@ type SeriesResult = {
   };
 };
 
-const queryParams = new URLSearchParams();
-queryParams.append("tag", "info/series/engineering-blog");
-queryParams.append("show-fields", "byline");
-queryParams.append("api-key", CAPI_KEY ?? "test");
+const queryParams = new URLSearchParams({
+  tag: "info/series/engineering-blog",
+  "show-fields": "byline",
+  "api-key": CAPI_KEY ?? "test",
+});
 
 const posts: SeriesResult[] = await fetch(
   `https://content.guardianapis.com/search?${queryParams.toString()}`

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly CAPI_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## What does this change?

The API key used to fetch content from CAPI is currently hardcoded with the `test` key. This means that the results for the blog feed are out of date.

This change loads the API key for CAPI from the `CAPI_KEY` environment variable, with a fallback value of `test`.