### PR TITLE
fix(bubbles): initial load state on iOS

### DIFF
--- a/src/components/Bubbles.svelte
+++ b/src/components/Bubbles.svelte
@@ -52,7 +52,7 @@
 
 <svelte:window bind:scrollY={scroll} />
 
-<aside class={ready && "ready"}>
+<aside class:ready>
   {#each layers as { speed, bubbles }}
     <div
       class="layer"
@@ -87,11 +87,14 @@
   @media (prefers-reduced-motion: no-preference) {
     aside {
       display: block;
+      position: absolute;
+      inset: 0;
+      overflow: hidden;
     }
 
     .layer {
       pointer-events: none;
-      position: fixed;
+      position: absolute;
       top: 0;
       left: 0;
       height: calc(var(--wrap) * 2);

--- a/src/layouts/page.astro
+++ b/src/layouts/page.astro
@@ -65,6 +65,7 @@ const { body, heading } = font;
     box-sizing: border-box;
     width: 100vw;
     max-width: 1300px;
+    position: relative;
     overflow-x: hidden;
     padding: 0.5rem;
 


### PR DESCRIPTION
## Why this change?

With a `fixed` position, the bubbles are all packed together at the top of the page on the first load. Using an `absolute` position fixes this issue, on my local device.