### PR TITLE
Fix style issues that appear at particular screen widths

### DIFF
--- a/src/components/Social.astro
+++ b/src/components/Social.astro
@@ -33,6 +33,7 @@ import {
   ul {
     list-style-type: none;
     padding: 0;
+    padding-right: 0.5em;
     display: flex;
     gap: 1em;
   }

--- a/src/pages/diversity.astro
+++ b/src/pages/diversity.astro
@@ -81,7 +81,18 @@ const title = "Diversity &amp; Inclusion";
   li {
     margin: 1em;
     padding: 1em;
-    width: 30%;
     background-color: #333;
+    width: 30%;
+  }
+
+  @media only screen and (max-width: 650px) {
+    ul {
+      flex-direction: column;
+    }
+
+    li {
+      box-sizing: border-box;
+      width: auto;
+    }
   }
 </style>


### PR DESCRIPTION
## What does this change?

- Adds a breakpoint for the Diversity page recruitment flex divs so that they are readable at small screen widths
- Adds some padding to the right of the social links so that it won't appear right up against the logo

## How to test

Run locally and visit the Diversity page. Does the recruitment section resize gracefully at smaller screen widths?

## Images

| Before: | After: |
| --- | ---|
| ![2022-06-06 13 54 26](https://user-images.githubusercontent.com/34686302/172164775-ff6460ac-024e-491a-9a76-06982055ff73.gif) | ![2022-06-06 13 52 54](https://user-images.githubusercontent.com/34686302/172164808-78b7a263-5e9e-4a31-8323-c0bb3c5a36b0.gif) |