### PR TITLE
fix: recently updated repositories "updated at" display

### DIFF
--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -16,7 +16,7 @@ const reposRaw: Array<{
 }> = await fetch(reposUrl).then((r) => r.json());
 
 /**
- * A mix of recently updated a most stargazed repos
+ * A mix of recently updated and most stargazed repos
  */
 const repos = reposRaw
   .filter((repo) => !repo.archived)

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -12,7 +12,7 @@ const reposRaw: Array<{
   html_url: string;
   stargazers_count: number;
   archived: boolean;
-  updated_at: string;
+  pushed_at: string;
 }> = await fetch(reposUrl).then((r) => r.json());
 
 /**
@@ -22,7 +22,7 @@ const repos = reposRaw
   .filter((repo) => !repo.archived)
   .sort(
     (a, b) =>
-      new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      new Date(b.pushed_at).getTime() - new Date(a.pushed_at).getTime()
   )
   .slice(0, 21)
   .sort((a, b) => b.stargazers_count - a.stargazers_count)
@@ -41,7 +41,7 @@ const repos = reposRaw
               <h4>{repo.name}</h4>
               <h5>
                 ({repo.stargazers_count} stars - updated{" "}
-                {timeAgo(new Date(repo.updated_at).getTime(), {
+                {timeAgo(new Date(repo.pushed_at).getTime(), {
                   daysUntilAbsolute: 1,
                 })}
                 )

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -41,7 +41,7 @@ const repos = reposRaw
               <h4>{repo.name}</h4>
               <h5>
                 ({repo.stargazers_count} stars - updated{" "}
-                {timeAgo(parseInt(repo.updated_at, 10), {
+                {timeAgo(new Date(repo.updated_at).getTime(), {
                   daysUntilAbsolute: 1,
                 })}
                 )

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -21,8 +21,7 @@ const reposRaw: Array<{
 const repos = reposRaw
   .filter((repo) => !repo.archived)
   .sort(
-    (a, b) =>
-      new Date(b.pushed_at).getTime() - new Date(a.pushed_at).getTime()
+    (a, b) => new Date(b.pushed_at).getTime() - new Date(a.pushed_at).getTime()
   )
   .slice(0, 21)
   .sort((a, b) => b.stargazers_count - a.stargazers_count)


### PR DESCRIPTION
## What does this change?

- Uses the `pushed_at` field which better represents when code was changed in the repository
  - the previous field, `updated_at`, indicates when the repository object was changed. This includes things like the description, wiki pages or primary language. [This StackOverflow post](https://stackoverflow.com/questions/15918588/github-api-v3-what-is-the-difference-between-pushed-at-and-updated-at) has more details
- Fixes the "updated at" display in the list of recently updated repositories. `repo.pushed_at` is an `ISO 8601` string, so we can create a `new Date(pushed_at)` and call `getTime()`

## Screenshots

| Before | After |
| - | - |
| <img width="703" alt="Screenshot 2022-08-10 at 11 55 31" src="https://user-images.githubusercontent.com/705427/183884677-23539a60-5ef4-41ee-9c1b-c7915bbbff14.png"> | <img width="691" alt="Screenshot 2022-08-10 at 11 55 19" src="https://user-images.githubusercontent.com/705427/183884698-98cd7661-e4de-44aa-8e72-52f4e69f0a1f.png"> |