### PR TITLE
fix(nav): nav should `overflow: auto`

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -27,7 +27,7 @@ const { path } = Astro.props;
 <style lang="scss" define:vars={{ border }}>
   nav {
     position: relative;
-    overflow-x: scroll;
+    overflow-x: auto;
     display: flex;
     border-bottom: var(--border);
 


### PR DESCRIPTION
## What does this change?

- Sets the nav bar to `overflow: auto` from `overflow: scroll`. With `overflow: scroll`, Firefox displays the scroll bars when not needed which looks odd!

## Screenshots (Firefox)

| | |
|--------| -- |
| Before |  ![before]     |
| After | ![after]  |

[after]: https://user-images.githubusercontent.com/705427/197163042-cda71b9b-af4e-465a-93e5-6a95c68a1383.png
[before]: https://user-images.githubusercontent.com/705427/197163049-1daca085-04c8-45b9-a422-8cfa053963fc.png


