### PR TITLE
fix: bubbles where cropped on large viewports

### DIFF
--- a/src/components/Bubbles.svelte
+++ b/src/components/Bubbles.svelte
@@ -91,6 +91,8 @@
       position: absolute;
       inset: 0;
       overflow: hidden;
+      width: 100vw;
+      left: min(calc((1300px - 100vw) / 2), 0px);
     }
 
     .layer {


### PR DESCRIPTION
## What does this change?

Ensure that the aside layer is takin the full width

## How to test

Run locally.

## How can we measure success?

Prettier bubbles that get out the way on desktop.

## Have we considered potential risks?

N/A

## Images

<img width="1652" alt="image" src="https://user-images.githubusercontent.com/76776/201332589-54f69c4e-4f1d-437b-918f-4519bd94d457.png">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [X] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
