### PR TITLE
refactor(diversity): use getHeadings method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[astro]": {
+    "editor.defaultFormatter": "astro-build.astro-vscode"
+  }
 }

--- a/src/pages/diversity.astro
+++ b/src/pages/diversity.astro
@@ -1,9 +1,9 @@
 ---
 import PageLayout from "../layouts/page.astro";
 
-import { Content as Diversity, getHeaders } from "../../content/diversity.md";
+import { Content as Diversity, getHeadings } from "../../content/diversity.md";
 
-const title = (await getHeaders())[0].text;
+const title = getHeadings()[0].text;
 ---
 
 <PageLayout {title} edit="diversity.astro">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import PageLayout from "../layouts/page.astro";
 import BlogFeed from "../components/BlogFeed.astro";
-import { Markdown } from "astro/components";
 
 import { border } from "../styles/shared.js";
 import home from "/assets/home-digital-development.jpg";

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -1,5 +1,4 @@
 ---
-import { timeAgo } from "@guardian/libs";
 import PageLayout from "../layouts/page.astro";
 import { Content } from "../../content/open-source.md";
 
@@ -26,6 +25,24 @@ const repos = reposRaw
   .slice(0, 21)
   .sort((a, b) => b.stargazers_count - a.stargazers_count)
   .slice(0, 10);
+
+const timeAgo = (date: Date) =>
+  `${
+    [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ][date.getMonth()]
+  } ${date.getDate()}, ${date.getFullYear()}`;
 ---
 
 <PageLayout title="Open Source" edit="open-source.astro">
@@ -40,10 +57,7 @@ const repos = reposRaw
               <h4>{repo.name}</h4>
               <h5>
                 ({repo.stargazers_count} stars - updated{" "}
-                {timeAgo(new Date(repo.pushed_at).getTime(), {
-                  daysUntilAbsolute: 1,
-                })}
-                )
+                {timeAgo(new Date(repo.pushed_at))})
               </h5>
               <p>{repo.description}</p>
             </a>


### PR DESCRIPTION
## What does this change?

async getHeaders is deprecated- refactor(diversity): use getHeadings method
- feat(formatter): use Astro plugin
- chore: remove unused import
- feat(timeAgo): absolute dates

## How to test

`pnpm dev`

## How can we measure success?

Resolves #190 

## Have we considered potential risks?

N/A

## Images

<img width="661" alt="image" src="https://user-images.githubusercontent.com/76776/210401317-bd5941a2-67d7-4176-8534-f55d813198a9.png">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [X] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
