### PR TITLE
fix: add name and version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "guardian-engineering-site",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## What does this change?

Add package name and version: `guardian-engineering-site@1.0.0`

## How to test

It’s right there.

## How can we measure success?

This is what `package.json` expects

## Have we considered potential risks?

N/A