### PR TITLE
fix padding on progression page

### DIFF
--- a/src/pages/progression.astro
+++ b/src/pages/progression.astro
@@ -20,7 +20,7 @@ const salaries = await fetch(
 ---
 
 <PageLayout title={title} edit="progression.astro">
-  <article set:html={performance} />
+  <article class="markdown" set:html={performance} />
 
   <p>
     Read more about it <a
@@ -31,5 +31,11 @@ const salaries = await fetch(
 
   <h1>Salary Bands</h1>
 
-  <article set:html={salaries} />
+  <article class="markdown" set:html={salaries} />
 </PageLayout>
+
+<style lang="scss">
+  .markdown {
+    padding: 0 1rem;
+  }
+</style>


### PR DESCRIPTION
## What does this change?

- Adds padding to markdown sections on the [Progression page](https://theguardian.engineering/progression)

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

| Before | After |
|--------|-------|
|    ![before](https://user-images.githubusercontent.com/705427/214567719-e643ca79-32ff-4afd-95a0-d597b1c163c3.png)    |     ![after](https://user-images.githubusercontent.com/705427/214567755-f05feeed-647e-4ae5-8675-f5f248c81346.png)  |

