### PR TITLE
Parse CAPI & DCR responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "sass": "1.57.1",
     "svelte": "4.2.8",
     "typescript": "5.1.6",
+    "valibot": "^0.28.1",
     "vite": "5.0.12",
     "web-vitals": "3.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ devDependencies:
   typescript:
     specifier: 5.1.6
     version: 5.1.6
+  valibot:
+    specifier: ^0.28.1
+    version: 0.28.1
   vite:
     specifier: 5.0.12
     version: 5.0.12(sass@1.57.1)
@@ -4273,6 +4276,10 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
+
+  /valibot@0.28.1:
+    resolution: {integrity: sha512-zQnjwNJuXk6362Leu0+4eFa/SMwRom3/hEvH6s1EGf3oXIPbo2WFKDra9ymnbVh3clLRvd8hw4sKF5ruI2Lyvw==}
     dev: true
 
   /vfile-location@5.0.2:

--- a/src/components/BlogFeed.astro
+++ b/src/components/BlogFeed.astro
@@ -1,23 +1,34 @@
 ---
+import {
+  parse,
+  object,
+  string,
+  number,
+  literal,
+  array,
+  picklist,
+  optional,
+} from "valibot";
 import { timeAgo } from "@guardian/libs";
 const CAPI_KEY = import.meta.env.CAPI_KEY ?? "test";
 
-type SeriesResult = {
-  id: string;
-  type: string;
-  sectionId: string;
-  sectionName: string;
-  webPublicationDate: string;
-  webTitle: string;
-  webUrl: string;
-  apiUrl: string;
-  isHosted: boolean;
-  pillarId: string;
-  pillarName: string;
-  fields: {
-    byline: string;
-  };
-};
+const searchResponseSchema = object({
+  response: object({
+    status: literal("ok"),
+    results: array(
+      object({
+        webUrl: string(),
+        webPublicationDate: string(),
+        webTitle: string(),
+        fields: optional(
+          object({
+            byline: string(),
+          })
+        ),
+      })
+    ),
+  }),
+});
 
 const queryParams = new URLSearchParams({
   tag: "info/series/engineering-blog",
@@ -25,65 +36,95 @@ const queryParams = new URLSearchParams({
   "api-key": CAPI_KEY,
 });
 
-const posts: SeriesResult[] = await fetch(
+const contentResultSchema = object({
+  mainMediaElements: array(
+    object({
+      data: object({
+        alt: string(),
+      }),
+      imageSources: array(
+        object({
+          weighting: picklist([
+            "inline",
+            "thumbnail",
+            "showcase",
+            "immersive",
+            "supporting",
+            "halfwidth",
+          ]),
+          srcSet: array(
+            object({
+              src: string(),
+              width: number(),
+            })
+          ),
+        })
+      ),
+    })
+  ),
+});
+
+const posts = await fetch(
   `https://content.guardianapis.com/search?${queryParams.toString()}`
 )
   .then((r) => r.json())
-  .then((d) => d.response.results);
+  .then((d) => parse(searchResponseSchema, d).response.results)
+  .then((r) =>
+    Promise.all(
+      r.slice(0, 9).map(async (post) => {
+        const time = new Date(post.webPublicationDate).getTime();
+        const pubDate = timeAgo(time);
 
-/**
- * It would be good to use https://raw.githubusercontent.com/guardian/dotcom-rendering/main/dotcom-rendering/src/model/json-schema.json
- */
-type ArticleResult = {
-  mainMediaElements: Array<{
-    data: {
-      alt: string;
-      caption: string;
-      credit: string;
-    };
-    imageSources: Array<{
-      weighting: "inline" | "thumbnail" | "showcase" | "immersive";
-      srcSet: Array<{
-        src: `https://i.guim.co.uk/${string}`;
-        width: number;
-      }>;
-    }>;
-  }>;
-};
+        const article = await fetch(post.webUrl + ".json?dcr")
+          .then((r) => r.json())
+          .then((d) => parse(contentResultSchema, d));
+
+        const media = article.mainMediaElements[0];
+
+        const { src, width } =
+          media?.imageSources
+            .find((source) => source.weighting === "inline")
+            ?.srcSet.slice()
+            .sort((a, b) => a.width - b.width)
+            .find((src) => src.width > 600) ?? {};
+
+        const image = {
+          src,
+          width,
+          alt: media?.data.alt,
+        };
+
+        return {
+          time,
+          image,
+          url: post.webUrl,
+          title: post.webTitle,
+          byline: post.fields?.byline,
+        };
+      })
+    )
+  );
 ---
 
 <h3>Latest Engineering blog posts</h3>
 <ul>
   {
-    posts.slice(0, 9).map(async (post) => {
-      const time = new Date(post.webPublicationDate).getTime();
-      const pubDate = timeAgo(time);
-
-      const article: ArticleResult = await fetch(
-        post.webUrl + ".json?dcr"
-      ).then((r) => r.json());
-
-      const media = article.mainMediaElements[0];
-
-      const image = media.imageSources
-        .find((source) => source.weighting === "inline")
-        .srcSet.slice()
-        .sort((a, b) => a.width - b.width)
-        .find((src) => src.width > 600);
-
-      return (
-        <li>
-          <a href={post.webUrl}>
-            <figure>
-              <img src={image.src} width={image.width} alt={media.data.alt} />
-            </figure>
-            <h4>{post.webTitle}</h4>
-            <h5 class="byline">{post.fields.byline}</h5>
-            <h5>{pubDate}</h5>
-          </a>
-        </li>
-      );
-    })
+    posts.map((post) => (
+      <li>
+        <a href={post.url}>
+          <figure>
+            <img
+              src={post.image.src}
+              width={post.image.width}
+              alt={post.image.alt}
+            />
+          </figure>
+          <h4>{post.title}</h4>
+          <h5 class="byline">{post.byline}</h5>
+          <h5>{timeAgo(post.time)}</h5>
+        </a>
+      </li>
+    ))
   }
 </ul>
 <a href="https://www.theguardian.com/info/series/engineering-blog"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "include": ["src"],
   "moduleResolution": "node",
   "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react"
   }


### PR DESCRIPTION
## What does this change?

Start parsing the responses from CAPI and DCR

## How to test

`pnpm build` works with an “internal” API key.

## How can we measure success?

A [recently updated article](https://www.theguardian.com/info/2018/may/02/the-digital-fellowship-is-your-foot-in-the-door-to-the-future-of-news) [caused failures in our Continuous Deployment](https://github.com/guardian/guardian-engineering-site/actions/workflows/cd.yml) process because it did not have an image.

**[CD works](https://github.com/guardian/guardian-engineering-site/actions/runs/7821077736/job/21337254416)**!

## Have we considered potential risks?

We’ll get errors at the fetch boundary, rather than deeply nested in our code.