### PR TITLE
Use Astro Image to optimise main image on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,9 +19,11 @@ import { Image } from "astro:assets";
     </div>
 
     <div class="flexedImage">
-      <img
+      <Image
         id="home"
-        src={home.src}
+        src={home}
+        height={home.height / 2}
+        width={home.width / 2}
         alt="Five people gathered around a table, with a man in the centre wearing an 'I heart the Guardian' tshirt"
       />
     </div>
@@ -65,6 +67,7 @@ import { Image } from "astro:assets";
     flex-wrap: wrap;
     justify-content: space-between;
     padding: 1rem;
+    gap: 1em;
   }
 
   // All but the first section
@@ -94,7 +97,6 @@ import { Image } from "astro:assets";
       display: flex;
       flex: 1 0 420px;
       align-items: center;
-      max-width: 100%;
     }
 
     a {
@@ -109,8 +111,9 @@ import { Image } from "astro:assets";
     }
 
     img {
-      object-fit: cover;
       max-width: 100%;
+      height: auto;
+      width: auto;
     }
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Uses Astro's [Image component](https://docs.astro.build/en/guides/images/#image--astroassets) for the main image on the homepage

## Why

The Image component displays an optimised version of the image. For example, it will use webp where available.

## Images - no visual change

| Before | After |
| - | - |
| ![b1] | ![a1] |
| ![b2] | ![a2] |
| ![b3] | ![a3] |

[b1]: https://github.com/guardian/guardian-engineering-site/assets/9574885/085aa909-eee0-4ee0-8448-f7abdd280686
[a1]: https://github.com/guardian/guardian-engineering-site/assets/9574885/a8bfb8b4-f16c-4cc9-ab4f-5c3442c2adb1
[b2]: https://github.com/guardian/guardian-engineering-site/assets/9574885/c2d41251-cf12-45d5-a41f-c65434bded7d
[a2]: https://github.com/guardian/guardian-engineering-site/assets/9574885/48d56504-cea8-4b53-b2c4-480d685fe3b5
[b3]: https://github.com/guardian/guardian-engineering-site/assets/9574885/c25b10ed-2d0d-40c8-8ffe-667826a3a8b8
[a3]: https://github.com/guardian/guardian-engineering-site/assets/9574885/aeba5d18-d7b8-4a5a-afb6-0eb5a2b0b5e8

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
