### PR TITLE
Blog | Add RSS Feed and meta description to blog pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@astrojs/mdx": "3.1.9",
     "@astrojs/react": "3.4.0",
+    "@astrojs/rss": "^4.0.12",
     "@astrojs/svelte": "5.4.0",
     "@babel/core": "7.20.12",
     "@emotion/babel-plugin": "11.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ dependencies:
   '@astrojs/react':
     specifier: 3.4.0
     version: 3.4.0(@types/react-dom@18.2.25)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)(vite@5.4.19)
+  '@astrojs/rss':
+    specifier: ^4.0.12
+    version: 4.0.12
   '@astrojs/svelte':
     specifier: 5.4.0
     version: 5.4.0(astro@4.16.18)(svelte@4.2.19)(typescript@5.3.3)(vite@5.4.19)
@@ -171,6 +174,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - vite
+    dev: false
+
+  /@astrojs/rss@4.0.12:
+    resolution: {integrity: sha512-O5yyxHuDVb6DQ6VLOrbUVFSm+NpObulPxjs6XT9q3tC+RoKbN4HXMZLpv0LvXd1qdAjzVgJ1NFD+zKHJNDXikw==}
+    dependencies:
+      fast-xml-parser: 5.2.5
+      kleur: 4.1.5
     dev: false
 
   /@astrojs/svelte@5.4.0(astro@4.16.18)(svelte@4.2.19)(typescript@5.3.3)(vite@5.4.19):
@@ -2469,6 +2479,13 @@ packages:
       micromatch: 4.0.8
     dev: false
 
+  /fast-xml-parser@5.2.5:
+    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
+    hasBin: true
+    dependencies:
+      strnum: 2.1.1
+    dev: false
+
   /fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
     dependencies:
@@ -4381,6 +4398,10 @@ packages:
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+    dev: false
+
+  /strnum@2.1.1:
+    resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
     dev: false
 
   /style-to-js@1.1.17:

--- a/src/components/BlogFeed.astro
+++ b/src/components/BlogFeed.astro
@@ -54,9 +54,8 @@ const thumbnail = (originalUrl) => {
     ))
   }
 </ul>
-<a href="https://www.theguardian.com/info/series/engineering-blog"
-  >Read more on our Engineering blog</a
->
+<a href="/blog">Read more on our Engineering blog</a>
+<a href="/blog/rss.xml">RSS Feed</a>
 
 <style lang="scss">
   ul {

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -22,6 +22,8 @@ const { path } = Astro.props;
   <a class={path === "/progression" ? "active" : ""} href="/progression">
     Progression
   </a>
+
+  <a class={path === "/blog" ? "active" : ""} href="/blog">Blog</a>
 </nav>
 
 <style lang="scss" define:vars={{ border }}>

--- a/src/components/blog/Header.astro
+++ b/src/components/blog/Header.astro
@@ -15,6 +15,7 @@ import Search from "astro-pagefind/components/Search";
     <ul>
       <li><a href="/blog/tags" class="contrast">Tags</a></li>
       <li><a href="/blog/authors" class="contrast">Authors</a></li>
+      <li><a href="/blog/rss.xml" class="contrast">RSS Feed</a></li>
     </ul>
   </nav>
 

--- a/src/layouts/blog.astro
+++ b/src/layouts/blog.astro
@@ -12,11 +12,11 @@ const sortByDate = (a, b) => {
 };
 
 const allPosts = Object.values(
-  import.meta.glob("../pages/blog/*.{md,mdx}", { eager: true }),
+  import.meta.glob("../pages/blog/*.{md,mdx}", { eager: true })
 ).sort(sortByDate);
 
 const postIndex = allPosts.findIndex(
-  (post) => post.frontmatter.slug === frontmatter.slug,
+  (post) => post.frontmatter.slug === frontmatter.slug
 );
 
 const nextIndex = postIndex === allPosts.length - 1 ? undefined : postIndex + 1;
@@ -34,7 +34,7 @@ const formatDate = (dateString) => {
 };
 ---
 
-<Base pageTitle={frontmatter.headline}>
+<Base pageTitle={frontmatter.headline} pageDescription={frontmatter.standfirst}>
   <main class="container" data-pagefind-body>
     <hgroup>
       <h1>{frontmatter.headline}</h1>

--- a/src/layouts/blog.astro
+++ b/src/layouts/blog.astro
@@ -12,11 +12,11 @@ const sortByDate = (a, b) => {
 };
 
 const allPosts = Object.values(
-  import.meta.glob("../pages/blog/*.{md,mdx}", { eager: true })
+  import.meta.glob("../pages/blog/*.{md,mdx}", { eager: true }),
 ).sort(sortByDate);
 
 const postIndex = allPosts.findIndex(
-  (post) => post.frontmatter.slug === frontmatter.slug
+  (post) => post.frontmatter.slug === frontmatter.slug,
 );
 
 const nextIndex = postIndex === allPosts.length - 1 ? undefined : postIndex + 1;

--- a/src/layouts/blog/Base.astro
+++ b/src/layouts/blog/Base.astro
@@ -1,5 +1,5 @@
 ---
-const { pageTitle } = Astro.props;
+const { pageTitle, pageDescription } = Astro.props;
 import Header from "../../components/blog/Header.astro";
 import Footer from "../../components/blog/Footer.astro";
 ---
@@ -20,8 +20,12 @@ import Footer from "../../components/blog/Footer.astro";
       href="https://assets.guim.co.uk/static/frontend/fonts/font-faces.css"
     />
 
-    <meta name="description" content="" />
-    <title>The guardian engineering blog - {pageTitle}</title>
+    <title>The Guardian Engineering Blog - {pageTitle}</title>
+    <meta
+      name="description"
+      content={pageDescription ??
+        "A blog by the Guardian's internal engineering team. We build and run the Guardian website, mobile apps, editorial tools, revenue products, advertising, and data and identity platforms. This blog is where we share our experiences and approaches, including software development tips, code examples, open source software and code stories behind product development."}
+    />
   </head>
 
   <body>

--- a/src/layouts/blog/Base.astro
+++ b/src/layouts/blog/Base.astro
@@ -26,6 +26,12 @@ import Footer from "../../components/blog/Footer.astro";
       content={pageDescription ??
         "A blog by the Guardian's internal engineering team. We build and run the Guardian website, mobile apps, editorial tools, revenue products, advertising, and data and identity platforms. This blog is where we share our experiences and approaches, including software development tips, code examples, open source software and code stories behind product development."}
     />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="The Guardian Engineering Blog"
+      href="/blog/rss.xml"
+    />
   </head>
 
   <body>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -3,7 +3,7 @@ import Base from "../layouts/blog/Base.astro";
 import PostList from "../components/blog/PostList.astro";
 
 const allPosts = Object.values(
-  import.meta.glob("./blog/*.{md,mdx}", { eager: true })
+  import.meta.glob("./blog/*.{md,mdx}", { eager: true }),
 );
 
 const sortedPosts = allPosts.sort((a, b) => {

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -3,7 +3,7 @@ import Base from "../layouts/blog/Base.astro";
 import PostList from "../components/blog/PostList.astro";
 
 const allPosts = Object.values(
-  import.meta.glob("./blog/*.{md,mdx}", { eager: true }),
+  import.meta.glob("./blog/*.{md,mdx}", { eager: true })
 );
 
 const sortedPosts = allPosts.sort((a, b) => {

--- a/src/pages/blog/rss.xml.js
+++ b/src/pages/blog/rss.xml.js
@@ -1,0 +1,36 @@
+import rss from "@astrojs/rss";
+
+export function GET(context) {
+  const allPosts = Object.values(
+    import.meta.glob("./*.{md,mdx}", { eager: true }),
+  );
+
+  const sortedPosts = allPosts.sort((a, b) => {
+    return new Date(b.frontmatter.date) - new Date(a.frontmatter.date);
+  });
+
+  return rss({
+    // `<title>` field in output xml
+    title: "The Guardian Engineering Blog",
+    // `<description>` field in output xml
+    description:
+      "A blog by the Guardian's internal engineering team. We build and run the Guardian website, mobile apps, editorial tools, revenue products, advertising, and data and identity platforms. This blog is where we share our experiences and approaches, including software development tips, code examples, open source software and code stories behind product development.",
+    // Pull in your project "site" from the endpoint context
+    // https://docs.astro.build/en/reference/api-reference/#site
+    site: "https://theguardian.engineering/blog",
+    // Array of `<item>`s in output xml
+    // See "Generating items" section for examples using content collections and glob imports
+    items: sortedPosts.map((post) => ({
+      title: post.frontmatter.headline,
+      description: post.frontmatter.standfirst,
+      link: `/blog/${post.frontmatter.slug}`,
+      pubDate: new Date(post.frontmatter.date),
+      author: post.frontmatter.authors
+        .filter((name) => name && name.trim())
+        .join(", "),
+      categories: post.frontmatter.tags.filter((tag) => tag && tag.trim()),
+    })),
+    // (optional) inject custom xml
+    customData: `<language>en-gb</language>`,
+  });
+}

--- a/src/pages/blog/rss.xml.js
+++ b/src/pages/blog/rss.xml.js
@@ -5,9 +5,11 @@ export function GET(context) {
     import.meta.glob("./*.{md,mdx}", { eager: true }),
   );
 
-  const sortedPosts = allPosts.sort((a, b) => {
-    return new Date(b.frontmatter.date) - new Date(a.frontmatter.date);
-  });
+  const sortedPosts = allPosts
+    .sort((a, b) => {
+      return new Date(b.frontmatter.date) - new Date(a.frontmatter.date);
+    })
+    .slice(0, 15); // Limit to the 15 most recent posts
 
   return rss({
     // `<title>` field in output xml


### PR DESCRIPTION
## What does this change?

- Adds a basic RSS Feed using [`@astrojs/rss`](https://docs.astro.build/en/recipes/rss/), which will be available at https://theguardian.engineering/blog/rss.xml

- Updates capitalisation on the `title`

- Adds `meta` `description` for SEO purposes

## How to test

- Checkout the branch locally, run development mode, and open the feed, potentially check with a rss feed reader/validator

## Notes

The `@astrojs/rss` plugin only supports RSS 2.0, we may want to support Atom feeds instead, as [Atom](https://en.wikipedia.org/wiki/Atom_(web_standard)) feeds are better defined.

@emdash-ie mentioned that it would also be useful to have the `content` included in the feed too, however the plugin doesn't interface with the built in rendering methods in Astro, and instead we have to rely on using an markdown processing package. It also doesn't play nicely with `mdx` files, so I haven't included the content for the time being.

We should also consider looking at using [Content Collections](https://docs.astro.build/en/guides/content-collections/) for the Engineering Blog as it marks a better way of structuring content rather than having to `import.meta.glob` the markdown files everywhere.

The better approach, which I, or someone else, can look into a future 10% time is to use the guidelines laid out within this post, which addresses most of the concerns above: https://gsong.dev/articles/astro-feed-unified/

For now this PR will be a useful starting spot for feed readers to use, and we can improve going forward!

