### PR TITLE
Fix | Blog | Remove trailing slash on rss feed

### DIFF
--- a/src/pages/blog/rss.xml.js
+++ b/src/pages/blog/rss.xml.js
@@ -34,5 +34,6 @@ export function GET(context) {
     })),
     // (optional) inject custom xml
     customData: `<language>en-gb</language>`,
+    trailingSlash: false, // Ensure no trailing slash in the URL
   });
 }


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/guardian-engineering-site/pull/239 we added an RSS feed available through https://theguardian.engineering/blog/rss.xml

However after deploying we noticed that the links wouldn't work

This is because the RSS feed plugin trailing slashes are applied by default, we have to remove them in order to get the links working with our project https://docs.astro.build/en/recipes/rss/#removing-trailing-slashes

This PR does that