### PR TITLE
fix: Update blog tag for consistency

### DIFF
--- a/src/pages/blog/day-in-the-life-simon-adcock.md
+++ b/src/pages/blog/day-in-the-life-simon-adcock.md
@@ -9,7 +9,7 @@ image:
   url: "/images/blog/simon-adcock.jpg"
   alt: "A picture of Simon"
   credit: "Photograph: Simon Adcock"
-tags: [DayInTheLife]
+tags: [Day in the Life]
 ---
 
 Simon Adcock’s fascination with computers began at home. His mother sensed the coming wave of technology and encouraged him to explore it through video games. Starting with an Atari and classics like Space Invaders, Simon was hooked. Soon he was experimenting with programming, though at first, it was a frustrating world of dry, complex books and few accessible courses.

--- a/src/pages/blog/day-in-the-life-stefano-le-pera.md
+++ b/src/pages/blog/day-in-the-life-stefano-le-pera.md
@@ -9,7 +9,7 @@ image:
   url: "/images/blog/stefano-le-pera.jpg"
   alt: "A picture of Stefano"
   credit: "Photograph: Stefano Le Pera"
-tags: [DayInTheLife]
+tags: [Day in the Life]
 ---
 
 Stefano Le Pera’s route into software engineering began in Rome, not through a traditional computer science degree, but through curiosity, creativity and a love of making things happen on screen. After trying economics and realising it was not the right path, he found himself drawn to digital design, where he became “the more technical person” among a largely artistic crowd. Then came Flash. “I loved it,” he says. “You could write a small bit of code and immediately see something happen.” That instant visual feedback pulled him deeper into development, and before long he was working as a Flash developer in Rome.


### PR DESCRIPTION
## What does this change?
Previous "day in the life posts use the tag "Day in the Life". This change updates the last two posts for consistency.

See also https://theguardian.engineering/blog/tags/Day%20in%20the%20Life vs https://theguardian.engineering/blog/tags/DayInTheLife.